### PR TITLE
The little details - Commands' category and description

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
                 "clojure.format.enable": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Enable/disable cljfmt as clojure formatter."
+                    "description": "Enable/disable cljfmt as clojure formatter"
                 },
                 "clojure4vscode.evalOnSave": {
                     "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -106,87 +106,87 @@
             {
                 "command": "clojure4vscode.connect",
                 "title": "connect",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.reconnect",
                 "title": "reconnect",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.toggleCLJCSession",
                 "title": "toggle repl connection used for CLJC files",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.selectCurrentForm",
                 "title": "evaluate selection or current form",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.evaluateSelection",
                 "title": "evaluate selection or current form",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.evaluateSelectionPrettyPrint",
                 "title": "evaluate selection or current form, and pretty print",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.evaluateSelectionReplace",
                 "title": "evaluate selection or current form, and replace it with the result",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.evaluateFile",
                 "title": "evaluate current file",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.lintFile",
                 "title": "lint current file",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.runNamespaceTests",
                 "title": "Run tests for current namespace",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.runAllTests",
                 "title": "Run all tests",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.rerunTests",
                 "title": "Run previus tests again",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.openREPLTerminal",
                 "title": "Open REPL terminal",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.loadNamespace",
                 "title": "Load current namespace in REPL terminal",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.setREPLNamespace",
                 "title": "Switch namespace in current terminal REPL to namespace of this file",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.evalCurrentFormInREPLTerminal",
                 "title": "Evaluate current form (or selection) in REPL terminal",
-                "category": "clojure4vscode"
+                "category": "Calva"
             },
             {
                 "command": "clojure4vscode.toggleAutoAdjustIndent",
                 "title": "Toggle auto adjusting of indent for new lines",
-                "category": "clojure4vscode"
+                "category": "Calva"
             }
         ],
         "keybindings": [

--- a/package.json
+++ b/package.json
@@ -105,47 +105,47 @@
         "commands": [
             {
                 "command": "clojure4vscode.connect",
-                "title": "connect",
+                "title": "Connect",
                 "category": "Calva"
             },
             {
                 "command": "clojure4vscode.reconnect",
-                "title": "reconnect",
+                "title": "Reconnect",
                 "category": "Calva"
             },
             {
                 "command": "clojure4vscode.toggleCLJCSession",
-                "title": "toggle repl connection used for CLJC files",
+                "title": "Toggle REPL connection used for CLJC files",
                 "category": "Calva"
             },
             {
                 "command": "clojure4vscode.selectCurrentForm",
-                "title": "evaluate selection or current form",
+                "title": "Select current form",
                 "category": "Calva"
             },
             {
                 "command": "clojure4vscode.evaluateSelection",
-                "title": "evaluate selection or current form",
+                "title": "Evaluate selection or current form",
                 "category": "Calva"
             },
             {
                 "command": "clojure4vscode.evaluateSelectionPrettyPrint",
-                "title": "evaluate selection or current form, and pretty print",
+                "title": "Evaluate selection or current form, and pretty print",
                 "category": "Calva"
             },
             {
                 "command": "clojure4vscode.evaluateSelectionReplace",
-                "title": "evaluate selection or current form, and replace it with the result",
+                "title": "Evaluate selection or current form, and replace it with the result",
                 "category": "Calva"
             },
             {
                 "command": "clojure4vscode.evaluateFile",
-                "title": "evaluate current file",
+                "title": "Evaluate current file",
                 "category": "Calva"
             },
             {
                 "command": "clojure4vscode.lintFile",
-                "title": "lint current file",
+                "title": "Lint current file",
                 "category": "Calva"
             },
             {


### PR DESCRIPTION
Hi @PEZ,

Not sure if it's okay to change a command's category to Calva - might confuse users? - but I did it to all of them. Also did some minor changes to commands description.

I just tried Calva with Shadow CLJS and it was easy to get it working, I'm very happy to see this! I've been teaching ClojureScript to new programmers and the editor integration has been a little bit of an issue. I use Cursive, but IDEs scare them off (I don't really understand it, it seems to be something psychological, not technical), and Emacs is even scarier and I'm not good at it to teach either. VSCode in the other hand is very popular and it's a very nice editor, so when they see that they can use VSCode for ClojureScript it's a thing less to learn (worry) and they feel more comfortable. 

I'm sure that the work you have done with Calva will make a newcomer's experience better and easier to get started. I hope more people give this extension a go! 😃